### PR TITLE
Check if key is defined befory loading the entity, fix array_flip warning

### DIFF
--- a/src/Plugin/views/filter/Selective.php
+++ b/src/Plugin/views/filter/Selective.php
@@ -457,10 +457,12 @@ class Selective extends InOperator {
                     $value = NULL;
 
                     if (NULL !== $entityTypeStorage) {
-                        $entity = $entityTypeStorage->load($key);
+                        if ($key) {
+                            $entity = $entityTypeStorage->load($key);
 
-                        if ($entity) {
-                            $value = $entity->label();
+                            if ($entity) {
+                                $value = $entity->label();
+                            }
                         }
                     }
                     else {

--- a/src/Plugin/views/filter/Selective.php
+++ b/src/Plugin/views/filter/Selective.php
@@ -456,13 +456,11 @@ class Selective extends InOperator {
                 foreach ((array) $keys as $key) {
                     $value = NULL;
 
-                    if (NULL !== $entityTypeStorage) {
-                        if ($key) {
-                            $entity = $entityTypeStorage->load($key);
+                    if (NULL !== $entityTypeStorage && $key) {
+                        $entity = $entityTypeStorage->load($key);
 
-                            if ($entity) {
-                                $value = $entity->label();
-                            }
+                        if ($entity) {
+                            $value = $entity->label();
                         }
                     }
                     else {

--- a/src/Plugin/views/filter/Selective.php
+++ b/src/Plugin/views/filter/Selective.php
@@ -7,7 +7,6 @@
 
 namespace Drupal\views_selective_filters\Plugin\views\filter;
 
-use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Form\FormStateInterface;
@@ -15,6 +14,7 @@ use Drupal\views\Plugin\views\display\DisplayPluginBase;
 use Drupal\views\Plugin\views\filter\InOperator;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Views;
+use Drupal\Component\Utility\Html;
 
 /**
  * Views filter handler for selective values.
@@ -172,9 +172,9 @@ class Selective extends InOperator {
                 '#theme' => 'status_messages',
                 '#message_list' => ['warning' => [$this->t('This filter is always exposed to users.')]],
                 '#status_headings' => [
-                    'status' => t('Status message'),
-                    'error' => t('Error message'),
-                    'warning' => t('Warning message'),
+                    'status' => $this->t('Status message'),
+                    'error' => $this->t('Error message'),
+                    'warning' => $this->t('Warning message'),
                 ],
             )));
         // Remove option to unexpose filter. Tried to disable, but did not work.
@@ -374,10 +374,11 @@ class Selective extends InOperator {
 
             // Check to see if the user remembered to add the field.
             if (empty($fields)) {
-                drupal_set_message(t('Selective query filter must have corresponding field added to view with Administrative Name set to "@name" and Base Type "@type"',
-                    array(
+                \Drupal::messenger()->addMessage('Selective query filter must have corresponding field added to view with Administrative Name set to "@name" and Base Type "@type"',
+                    [
                         '@name' => $ui_name,
-                        '@type' => $base_field)),
+                        '@type' => $base_field
+                    ],
                     'error');
                 return [];
             }
@@ -399,10 +400,11 @@ class Selective extends InOperator {
                 ($field_options['relationship'] === $this->options['relationship']);
 
             if (!$equal) {
-                drupal_set_message(t('Selective filter "@name": relationship of field and filter must match.',
-                    array(
+                \Drupal::messenger()->addMessage('Selective filter "@name": relationship of field and filter must match.',
+                    [
                         '@name' => $ui_name,
-                        '@type' => $base_field)),
+                        '@type' => $base_field,
+                    ],
                     'error');
                 return [];
             }
@@ -469,7 +471,7 @@ class Selective extends InOperator {
                     }
 
                     if (NULL !== $value) {
-                        $oids[$key] = SafeMarkup::checkPlain($value);
+                        $oids[$key] = Html::escape($value);
                     }
                 }
             }
@@ -500,7 +502,7 @@ class Selective extends InOperator {
 
             // If limit exceeded this field is not good for being "selective".
             if (!empty($max_items) && count($oids) === $max_items) {
-                drupal_set_message(t('Selective filter "@field" has limited the amount of total results. Please, review you query configuration.', array('@field' => $ui_name)), 'warning');
+                \Drupal::messenger()->addMessage('Selective filter "@field" has limited the amount of total results. Please, review you query configuration.', ['@field' => $ui_name], 'warning');
             }
 
             static::$results[$signature] = $oids;

--- a/views_selective_filters.info.yml
+++ b/views_selective_filters.info.yml
@@ -3,6 +3,6 @@ type: module
 description: Restrict exposed filter values to those present in the result set.
 package: Views
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - drupal:views

--- a/views_selective_filters.info.yml
+++ b/views_selective_filters.info.yml
@@ -3,5 +3,6 @@ type: module
 description: Restrict exposed filter values to those present in the result set.
 package: Views
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
-  - views
+  - drupal:views


### PR DESCRIPTION
On a view with multiple selective filters I had this warning showing up (only for anonymous users):

```
Warning: array_flip(): Can only flip STRING and INTEGER values! in Drupal\Core\Entity\EntityStorageBase->loadMultiple() (line 227 of core/lib/Drupal/Core/Entity/EntityStorageBase.php).

Drupal\Core\Entity\EntityStorageBase->loadMultiple(Array) (Line: 212)
Drupal\Core\Entity\EntityStorageBase->load() (Line: 461)
Drupal\views_selective_filters\Plugin\views\filter\Selective->getOids() (Line: 86)
```

It appears that the `$key` was sometimes false.